### PR TITLE
Allow by day segment sampling

### DIFF
--- a/ui/app/static/main.css
+++ b/ui/app/static/main.css
@@ -168,6 +168,15 @@ form {
     color: #a08bb3;
 }
 
+.form-check {
+    margin-bottom: 1rem;
+}
+
+/* Global hidden class */
+.hidden {
+    display: none;
+}
+
 /* .styled-table tr > *:nth-child(2) {
     display: none;
 } */

--- a/ui/app/templates/lenasampler/sampling.html
+++ b/ui/app/templates/lenasampler/sampling.html
@@ -8,7 +8,7 @@
                 <h4> Sampling Criteria </h4>
             </div>
             <div class="row">
-                {{ wtf.quick_form(form) }}
+                {{ wtf.quick_form(form, id="sampling-form") }}
             </div>
         </div>
         <div class="col-6" style="margin-left: 20px;">
@@ -38,7 +38,7 @@
                             </tbody>
                         </table>
                     </div>
-                </div> 
+                </div>
                 {% endif %}
             </div>
         </div>
@@ -47,6 +47,17 @@
 
 <script>
     $(document).ready( function () {
+        const checkBox = document.getElementById("sample-by-day");
+        const toggleFields= () => document
+            .querySelectorAll(".form-group > input:not(#num-segments)")
+            .forEach(input => input.parentElement.classList.toggle("hidden"));
+
+        if (checkBox) {
+            if (checkBox.checked) {
+                toggleFields();
+            }
+            checkBox.onclick = toggleFields;
+        }
         $.noConflict();
         $('#datainput').DataTable( {
             dom: 'Bfrtip',
@@ -62,4 +73,4 @@
     } );
 </script>
 
-{% endblock %} 
+{% endblock %}

--- a/ui/app/templates/lenasampler/sampling.html
+++ b/ui/app/templates/lenasampler/sampling.html
@@ -8,7 +8,7 @@
                 <h4> Sampling Criteria </h4>
             </div>
             <div class="row">
-                {{ wtf.quick_form(form, id="sampling-form") }}
+                {{ wtf.quick_form(form) }}
             </div>
         </div>
         <div class="col-6" style="margin-left: 20px;">
@@ -48,6 +48,8 @@
 <script>
     $(document).ready( function () {
         const checkBox = document.getElementById("sample-by-day");
+
+        // Helper for hidding input fields
         const toggleFields= () => document
             .querySelectorAll(".form-group > input:not(#num-segments)")
             .forEach(input => input.parentElement.classList.toggle("hidden"));


### PR DESCRIPTION
Changes:
- Add a check box input for sampling by only top samples (instead of random)
  - Checkbox only shows if only one sampling column is used
- If checkbox is checked hide input fields except number of segments, if unchecked then normal random sampling is used
- Number of segments input will be used to determine how many of the top segments are needed for each day